### PR TITLE
Fixed the default asset paths

### DIFF
--- a/inc/class-lp-assets.php
+++ b/inc/class-lp-assets.php
@@ -173,7 +173,7 @@ class LP_Assets {
 
 	public static function add_default_scripts( &$scripts ) {
 
-		$default_path = '/wp-content/plugins/learnpress/assets/';
+		$default_path = plugins_url('learnpress/assets/');
 		$suffix       = '';
 		$deps         = array( 'jquery', 'backbone', 'utils' );
 
@@ -237,7 +237,7 @@ class LP_Assets {
 	}
 
 	public static function add_default_styles( &$styles ) {
-		$default_path = '/wp-content/plugins/learnpress/assets/';
+		$default_path = plugins_url('learnpress/assets/');
 		$suffix       = '';
 		// global
 		$styles->add( 'learn-press-global', $default_path . 'css/global' . $suffix . '.css' );


### PR DESCRIPTION
Hey LearnPress, when using [Bedrock](https://roots.io/bedrock/), the wp-content folder is replaced with the app folder. My scripts and styles didn't work anymore, i fixed it with the plugins_url function.