### PR TITLE
unnecessary condition removed from pricing since it always returns false

### DIFF
--- a/templates/single-course/price.php
+++ b/templates/single-course/price.php
@@ -11,10 +11,6 @@ if ( !defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 $course = LP()->global['course'];
-
-if ( learn_press_is_enrolled_course() ) {
-	return;
-}
 ?>
 <?php if ( $price = $course->get_price_html() ) {
 


### PR DESCRIPTION
If no parameter is passed when using learn_press_is_enrolled_course() function, it always returns false. So it's unnecessary to use it without parameters