### PR TITLE
Update get_preview_courses() to return Course posts only

### DIFF
--- a/inc/class-lp-preview-course.php
+++ b/inc/class-lp-preview-course.php
@@ -161,12 +161,13 @@ class LP_Preview_Course {
 			$query = $wpdb->prepare( "
 				SELECT ID
 				FROM {$wpdb->posts} p
-				WHERE post_author = 0
+				WHERE post_author = 0 AND post_type = %s
 				UNION 
 				SELECT post_id
 				FROM {$wpdb->postmeta}
 				WHERE meta_key = %s AND meta_value = %s
-			", '_lp_preview_course', 'yes' );
+			", LP_COURSE_CPT, '_lp_preview_course', 'yes' );
+
 
 			$ids = $wpdb->get_col( $query );
 			wp_cache_set( 'preview-courses', $ids, 'learnpress' );

--- a/inc/class-lp-preview-course.php
+++ b/inc/class-lp-preview-course.php
@@ -168,7 +168,6 @@ class LP_Preview_Course {
 				WHERE meta_key = %s AND meta_value = %s
 			", LP_COURSE_CPT, '_lp_preview_course', 'yes' );
 
-
 			$ids = $wpdb->get_col( $query );
 			wp_cache_set( 'preview-courses', $ids, 'learnpress' );
 		}


### PR DESCRIPTION
This PR updates `get_preview_courses()` to limit the results to the ID of those records that have `post_type = 'lp_course'`.