### PR TITLE
Mz bug fixs

### DIFF
--- a/inc/admin/lp-admin-actions.php
+++ b/inc/admin/lp-admin-actions.php
@@ -237,7 +237,7 @@ function learn_press_admin_course_tabs() {
 
 	$current_page_id = get_current_screen()->id;
 	$current_user    = wp_get_current_user();
-	if ( ! in_array( 'administrator', $current_user->roles ) ) {
+	if (! current_user_can( 'manage_categories' ) ) {
 		return;
 	}
 	if ( ! empty( $admin_tabs_on_page[ $current_page_id ] ) && count( $admin_tabs_on_page[ $current_page_id ] ) ) {

--- a/inc/custom-post-types/course.php
+++ b/inc/custom-post-types/course.php
@@ -550,7 +550,7 @@ if ( ! class_exists( 'LP_Course_Post_Type' ) ) {
 				);
 			}
 
-			if ( is_super_admin() ) {
+			if ( current_user_can('edit_author_' . LP_COURSE_CPT . 's') ) {
 				$default_tabs['author'] = new RW_Meta_Box( self::author_meta_box() );
 			}
 

--- a/inc/user/lp-user-functions.php
+++ b/inc/user/lp-user-functions.php
@@ -215,6 +215,7 @@ function learn_press_add_user_roles() {
 		$admin->add_cap( 'edit_private_' . $course_cap );
 		$admin->add_cap( 'delete_others_' . $course_cap );
 		$admin->add_cap( 'edit_others_' . $course_cap );
+		$admin->add_cap( 'edit_author_' . $course_cap );
 
 		$admin->add_cap( 'delete_' . $lesson_cap );
 		$admin->add_cap( 'delete_published_' . $lesson_cap );

--- a/learnpress.php
+++ b/learnpress.php
@@ -216,6 +216,7 @@ if ( ! class_exists( 'LearnPress' ) ) {
 		 * Includes needed files.
 		 */
 		public function includes() {
+                        require_once ABSPATH . 'wp-includes/pluggable.php' ;
 			require_once 'inc/class-lp-exception.php';
 			require_once 'inc/class-lp-helper.php';
 			require_once 'inc/class-lp-settings.php';


### PR DESCRIPTION
Add this line "require_once ABSPATH . 'wp-includes/pluggable.php' ;" to fix get current language for the current admin user
Fix: make categories and tags editable by manage_categories capability, not Administrator Role only
Fix: make course author editable by new capability edit_author_lp_courses not Administrator Role only