### PR TITLE
fix missing updates to vue store when sorting answers

### DIFF
--- a/assets/js/admin/question-editor.js
+++ b/assets/js/admin/question-editor.js
@@ -156,7 +156,7 @@ var $VueHTTP = Vue.http;
                 function (response) {
                     var result = response.body;
                     if (result.success) {
-                        // context.commit('SET_ANSWERS', result.data);
+                        context.commit('SET_ANSWERS', result.data);
                     }
                 }
             )

--- a/assets/js/admin/quiz-editor.js
+++ b/assets/js/admin/quiz-editor.js
@@ -290,11 +290,13 @@ var LP_List_Quiz_Questions_Store = (function (helpers, data, $) {
                 return question;
             });
         },
-        'SORT_QUESTION_ANSWERS': function (state, orders) {
+        'SORT_QUESTION_ANSWERS': function (state, data) {
             state.questions = state.questions.map(function (question) {
-                question.answers.answer_order = orders[question.answers.question_answer_id];
+                if (parseInt(question.id) === data.id) {
+                    question.answers = data.answers;
+                }
                 return question;
-            })
+            });
         },
         'ADD_QUESTION_ANSWER': function (state, payload) {
             state.questions = state.questions.map(function (question) {

--- a/inc/admin/editor/class-lp-admin-editor-quiz.php
+++ b/inc/admin/editor/class-lp-admin-editor-quiz.php
@@ -341,7 +341,8 @@ class LP_Admin_Editor_Quiz extends LP_Admin_Editor {
 		}
 
 		// sort answer
-		$this->result = $this->question_curd->sort_answers( $question_id, $order );
+		$question = $this->question_curd->sort_answers( $question_id, $order );
+		$this->result = $this->get_question_data_to_quiz_editor( $question, true );
 
 		return true;
 	}

--- a/inc/admin/views/question/answer.php
+++ b/inc/admin/views/question/answer.php
@@ -22,7 +22,8 @@ learn_press_admin_view( 'question/option' );
             </thead>
             <tbody>
             <!--            <draggable :list="answers" :element="'tbody'" @end="sort">-->
-            <lp-question-answer-option v-for="(answer, index) in answers" :key="index" :index="index" :type="type"
+            <lp-question-answer-option v-for="(answer, index) in answers" :key="answer.question_answer_id"
+                                       :index="index" :type="type"
                                        :radio="radio" :number="number" :answer="answer"
                                        @updateTitle="updateTitle"
                                        @changeCorrect="changeCorrect"


### PR DESCRIPTION
this pull request tries to solve the following problem:

when re-ordering the answers of a question (any) the Vue store is not updated. due to https://github.com/LearnPress/learnpress/blob/9c4d812de53136faf0a927c009a58d6fca1b4ea5/assets/js/admin/question-editor.js#L151-L163 being castrated. That means, the Vue store is out of sync with the database, when only order is being changed.

The change originally was probably done because another underlying problem causes some very weird behaviour that only *appears* to be fixed with the castration. ("spoiler": it's a "broken" vue redraw of the answers, that is the cause of the display problem)