### PR TITLE
Fix when save order payment code updated from title

### DIFF
--- a/inc/curds/class-lp-order-curd.php
+++ b/inc/curds/class-lp-order-curd.php
@@ -70,7 +70,7 @@ class LP_Order_CURD extends LP_Object_Data_CURD implements LP_Interface_CURD {
 			'_order_subtotal'       => $order->get_subtotal(),
 			'_order_total'          => $order->get_total(),
 			'_order_key'            => $order->get_order_key(),
-			'_payment_method'       => $order->get_payment_method_title(),
+			'_payment_method'       => $order->get_payment_method(),
 			'_payment_method_title' => $order->get_payment_method_title(),
 			'_user_ip_address'      => $order->get_user_ip_address(),
 			'_user_agent'           => $order->get_user_agent(),


### PR DESCRIPTION
Fix when save order payment code updated from title

When update a status order the payment method code change to title and generate error to excute action

do_action( 'learn-press/order/received/' . $order->payment_method, $order->id );