### PR TITLE
check for payment curl bugs and alert users

### DIFF
--- a/inc/class-lp-checkout.php
+++ b/inc/class-lp-checkout.php
@@ -701,7 +701,19 @@ class LP_Checkout {
 							wp_redirect( $result['redirect'] );
 							exit;
 						}
+					} else {
+
+						$messages = isset( $result['messages'] ) ? $result['messages'] : false;
+
+						if ( $messages ) {
+
+							foreach ( $messages as $message ) {
+
+								learn_press_add_message( $message, 'error' );
+							}
+						}
 					}
+
 				} else {
 					// ensure that no order is waiting for payment
 					$order = new LP_Order( $order_id );


### PR DESCRIPTION
I've been working with a payment driver to integrate it with learnpress and my problem was weird because there was nothing executed after pressing checkout button so I got deeper and found out errors from payment driver are not managed and there is no way we could add error messages from payment class.

this block of code will solve that problem.