### PR TITLE
Fix `get_course_data` method if checking for not logged in user

### DIFF
--- a/inc/user/abstract-lp-user.php
+++ b/inc/user/abstract-lp-user.php
@@ -126,7 +126,10 @@ if ( ! class_exists( 'LP_Abstract_User' ) ) {
 					 * Todo: some themes still not check false, so still use below code.\
 					 * @editor tungnx 4.1.6.9
 					 */
-					$object_course_data = new LP_User_Item_Course( $course_id );
+					$object_course_data = new LP_User_Item_Course( array(
+						'item_id' => $course_id,
+						'user_id' => $this->get_id(),
+					) );
 				}
 			} catch ( Throwable $e ) {
 				$object_course_data = false;


### PR DESCRIPTION
If we don't declare user ID in `LP_User_Item_Course` constructor, it will use result of `get_current_user_id()` (in /inc/user-item/class-lp-user-item.php, line 121), which might return wrong user item.