### PR TITLE
Add user ID to `learn-press/user/is-course-enrolled` filter

### DIFF
--- a/inc/user/class-lp-user.php
+++ b/inc/user/class-lp-user.php
@@ -223,7 +223,7 @@ class LP_User extends LP_Abstract_User {
 			$result_check->message = $th->getMessage();
 		}
 
-		return apply_filters( 'learn-press/user/is-course-enrolled', $return_bool ? $result_check->check : $result_check, $course_id, $return_bool );
+		return apply_filters( 'learn-press/user/is-course-enrolled', $return_bool ? $result_check->check : $result_check, $this->get_id(), $course_id, $return_bool );
 	}
 
 	/**


### PR DESCRIPTION
Without user ID we're unable to filter output, because we don't know who the user is.