### PR TITLE
Fix String Translation in html-clean-database.php

### DIFF
--- a/inc/admin/views/tools/database/html-clean-database.php
+++ b/inc/admin/views/tools/database/html-clean-database.php
@@ -60,7 +60,7 @@ $clean_tables = array( 'learnpress_sessions' );
 						<h4><?php echo sprintf('%s: %s', esc_html__( 'Table name', 'learnpress' ), $clean_table ); ?></h4>
 						<div class="progressbar__indexs">
 							<span class="progressbar__rows">
-								<?php echo esc_html( '0 / ' . $rows . ' expire' ); ?>
+								<?php echo esc_html( '0 / ' . $rows . __( ' expire', 'learnpress' ) ); ?>
 							</span>
 							<span class="progressbar__percent">( 0% )</span>
 						</div>


### PR DESCRIPTION
Fix String Translation in html-clean-database.php

Fix: https://wordpress.org/support/topic/this-string-included-in-this-esc_html-function-is-not-translatable/