### PR TITLE
Update class-lp-cart.php

### DIFF
--- a/inc/cart/class-lp-cart.php
+++ b/inc/cart/class-lp-cart.php
@@ -203,24 +203,25 @@ class LP_Cart {
 	/**
 	 * Remove an item from cart
 	 *
-	 * @param $item_id
+	 * @param $cart_id
 	 *
 	 * @return bool
 	 */
-	public function remove_item( $item_id ) {
-		if ( isset( $this->_cart_content['items'][ $item_id ] ) ) {
+	public function remove_item( $cart_id ) {
+		
+		if ( isset( $this->_cart_content[ $cart_id ] ) ) {
+			
+			do_action( 'learn_press_remove_cart_item', $cart_id, $this );
 
-			do_action( 'learn_press_remove_cart_item', $item_id, $this );
+			unset( $this->_cart_content[$cart_id] );
 
-			unset( $this->_cart_content['items'][ $item_id ] );
-
-			do_action( 'learn_press_cart_item_removed', $item_id, $this );
+			do_action( 'learn_press_cart_item_removed', $cart_id, $this );
 
 			$this->update_session( $this->_cart_content );
 
 			return true;
 		}
-
+		
 		return false;
 	}
 


### PR DESCRIPTION
protected __cart_content has no key "items". Hence the remove_item method in LP_Cart never actually worked. 

Now the remove_item() method of _cart_content takes $cart_id as parameter and removes item if cart_id exists in _cart_content