### PR TITLE
Removed test cases in course buttons

### DIFF
--- a/inc/templates/class-lp-template-course.php
+++ b/inc/templates/class-lp-template-course.php
@@ -180,13 +180,6 @@ class LP_Template_Course extends LP_Abstract_Template {
 	 * @version 4.0.2
 	 */
 	public function course_purchase_button( $course = null ) {
-		// Test
-		$singleCourseTemplate = SingleCourseTemplate::instance();
-		$course               = CourseModel::find( get_the_ID(), true );
-		$user                 = UserModel::find( get_current_user_id(), true );
-		echo $singleCourseTemplate->html_btn_purchase_course( $course, $user );
-		return;
-		// End test
 
 		$can_show = true;
 		if ( empty( $course ) ) {
@@ -253,13 +246,6 @@ class LP_Template_Course extends LP_Abstract_Template {
 	 * @version 4.0.3
 	 */
 	public function course_enroll_button( $course = null ) {
-		// Test
-		$singleCourseTemplate = SingleCourseTemplate::instance();
-		$course               = CourseModel::find( get_the_ID(), true );
-		$user                 = UserModel::find( get_current_user_id(), true );
-		echo $singleCourseTemplate->html_btn_enroll_course( $course, $user );
-		return;
-		// End test
 
 		$can_show = true;
 		$user     = learn_press_get_current_user();


### PR DESCRIPTION
Removed test cases from the functions course_purchase_button & course_enroll_button in class-lp-template-course.php as it prevented custom hooks and button templates in child themes from working.

All the logic after the return was ignored, thus making can_show not function as well (not tested thoroughly). Removing the test makes custom templates work again.

