### PR TITLE
Fix Payment Gateway Integration Support

### DIFF
--- a/inc/gateways/class-lp-gateways.php
+++ b/inc/gateways/class-lp-gateways.php
@@ -52,7 +52,9 @@ class LP_Gateways {
 				foreach ( $gateways as $k => $gateway ) {
 					if ( is_string( $gateway ) && class_exists( $gateway ) ) {
 						$gateway = new $gateway();
+					}
 
+					if ($gateway instanceof LP_Gateway_Abstract) {
 						$this->payment_gateways[ $k ] = $gateway;
 					}
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === LearnPress - WordPress LMS Plugin ===
-Contributors: thimpress, tungnx89, nhamdv, nguyenlammanh, tunnhn, phonglq.foobla, thongta, kendy73, leehld
+Contributors: thimpress, tungnx89, nhamdv, nguyenlammanh, tunnhn, phonglq.foobla, thongta, kendy73, leehld, GautamMKGarg
 Donate link:
 Tags: elearning, education, course, lms, learning management system
 Tested up to: 6.7


### PR DESCRIPTION
Fixing the issue reported at below link

https://wordpress.org/support/topic/version-4-2-7-8-has-broken-payment-gateway-integration/

After this change, payment gateway class can be initialized while using the filter learn-press/payment-methods. This was already there but removed in recent update because of which Knit Pay supported working.