### PR TITLE
Add user context to course enrollment filter

### DIFF
--- a/inc/user/class-lp-user.php
+++ b/inc/user/class-lp-user.php
@@ -226,7 +226,7 @@ class LP_User extends LP_Abstract_User {
 			$result_check->message = $th->getMessage();
 		}
 
-		return apply_filters( 'learn-press/user/is-course-enrolled', $return_bool ? $result_check->check : $result_check, $course_id, $return_bool );
+		return apply_filters( 'learn-press/user/is-course-enrolled', $return_bool ? $result_check->check : $result_check, $course_id, $return_bool, $this );
 	}
 
 	/**


### PR DESCRIPTION
Without user info we're unable to filter output, because we don't know who the user is (get_current_user_id() is not always relevant).