### PR TITLE
Fix course item templates with custom course layouts

### DIFF
--- a/inc/Gutenberg/GutenbergHandleMain.php
+++ b/inc/Gutenberg/GutenbergHandleMain.php
@@ -142,7 +142,7 @@ class GutenbergHandleMain {
 	 *
 	 * @return array
 	 * @since 4.2.2.3
-	 * @version 1.0.6
+	 * @version 1.0.7
 	 */
 	public function set_blocks_template( array $query_result, array $query, $template_type ): array {
 		if ( $template_type === 'wp_template_part' ) { // Template not Template part
@@ -161,6 +161,8 @@ class GutenbergHandleMain {
 			$lp_course_item = learn_press_get_post_by_name( $vars['course-item'] ?? '', $item_type );
 			$item_types     = CourseModel::item_types_support();
 			if ( $lp_course_item && in_array( $lp_course_item->post_type, $item_types ) ) {
+				// Course items use their own template, not a course-level theme or post template.
+				$query_result                  = [];
 				$singleCourseItemBlockTemplate = new SingleCourseItemBlockTemplate();
 				$block_custom                  = $this->is_custom_block_template( $template_type, $singleCourseItemBlockTemplate->slug );
 				if ( $block_custom ) {


### PR DESCRIPTION
### What changed

Clear competing block-template candidates after LearnPress confirms that the request is for a course item. The existing `SingleCourseItemBlockTemplate` is then the only candidate for lesson and quiz routes.

### Why

A course-level custom template appears first in WordPress's single-template hierarchy. LearnPress previously appended its item template without removing that higher-priority course template, so lesson and quiz URLs rendered the course overview. LearnPress still added `course-item-popup`, leaving the page unable to scroll normally.

Course overview requests do not enter this branch, so their assigned custom templates remain unchanged. Custom `single-lp_course_item` templates are still loaded into the item template before it is appended.

Closes #636

### Testing

Tested with WordPress 7.0.3, LearnPress 4.4.4, PHP 8.4, Assembler 0.0.29, and Twenty Twenty-Five 1.5.

| Theme | Assigned course template | Lesson/quiz before | Lesson/quiz after |
| --- | --- | --- | --- |
| Assembler | Default | Works | Works |
| Assembler | Custom | Course overview renders; page cannot scroll | Course item renders |
| Twenty Twenty-Five | Default | Works | Works |
| Twenty Twenty-Five | Custom | Course overview renders; page cannot scroll | Course item renders |

Also verified:

- Logged-in and logged-out requests.
- Course overview keeps its assigned custom template.
- Custom Single Course Item template still renders.
- `phpcs --standard=phpcs.xml inc/Gutenberg/GutenbergHandleMain.php`
- `php -l inc/Gutenberg/GutenbergHandleMain.php`
- `git diff --check`

The full PHPUnit suite was attempted on the current `develop` branch but does not complete because existing tests reference missing subscription files and later redeclare `learn_press_get_order()`.
