### PR TITLE
perf: prime curriculum item post caches before rendering

### DIFF
--- a/inc/TemplateHooks/Course/SingleCourseTemplate.php
+++ b/inc/TemplateHooks/Course/SingleCourseTemplate.php
@@ -1500,6 +1500,19 @@ class SingleCourseTemplate {
 			}
 
 			wp_enqueue_script( 'lp-curriculum' );
+			
+			$item_ids = [];
+
+			foreach ( $section_items as $section_item ) {
+				foreach ( $section_item->items as $item ) {
+					$item_ids[] = (int) $item->item_id;
+				}
+			}
+
+			if ( $item_ids ) {
+				_prime_post_caches( $item_ids, false, true );
+			}
+			
 			$li_section_items = '';
 			foreach ( $section_items as $section_item ) {
 				$li_section_items .= $this->render_html_section_item( $courseModel, $userModel, $section_item );


### PR DESCRIPTION
<img width="734" height="513" alt="Screenshot 2026-09-07 at 3 06 13 PM" src="https://github.com/user-attachments/assets/d6bed7dd-e7a4-4895-be48-b80eb50e2ff1" />


perf: prime curriculum item post caches before rendering

Avoid repeated post lookups while rendering course curriculum items by
priming the WordPress post cache for all curriculum item IDs before the
section items are rendered.

Collect the post IDs from all curriculum sections and call
`_prime_post_caches()` once with the complete list. This allows WordPress
to load the required post objects into the object cache in advance,
reducing repeated `get_post()` database queries during curriculum
rendering.

The cache is primed only when curriculum item IDs are available, avoiding
an unnecessary cache operation for empty sections.

This improves the performance of single-course curriculum rendering,
particularly for courses containing a large number of lessons, quizzes,
and other curriculum items.
